### PR TITLE
Fixed chrome.tabs.getSelected() to return a single Tab object, not an array of Tab objects

### DIFF
--- a/src/browser/tabs.ts
+++ b/src/browser/tabs.ts
@@ -137,9 +137,9 @@ export class TabsAPI extends EventEmitter implements ITabsEvents {
   // Deprecated, fallback to chrome.tabs.query
   public getSelected(windowId: number) {
     if (typeof windowId === 'number') {
-      return this.query({ windowId, active: true });
+      return this.query({ windowId, active: true })[0];
     }
-    return this.query({ active: true });
+    return this.query({ active: true })[0];
   }
 
   public query(info: chrome.tabs.QueryInfo = {}) {


### PR DESCRIPTION
Fixes issue #28 
